### PR TITLE
Cambio `guerrero` por `misiles`

### DIFF
--- a/00001_Una jerarquía complicada/description.md
+++ b/00001_Una jerarquía complicada/description.md
@@ -39,7 +39,7 @@ Unidad <|--Muralla
 Como vemos, tenemos guerreros, murallas, magos y misiles:
 
 * las murallas entienden `defender`, pero no `atacar`
-* los guerrero entienden `atacar`, pero no `defender`
+* los misiles entienden `atacar`, pero no `defender`
 * los magos no atacan ni defienden
 * los guerreros atacan y defienden
 


### PR DESCRIPTION
La descripción tiene un error donde dice que los guerreros entienden atacar pero no defender, cuando los que están en esa situación son los misiles.